### PR TITLE
[#1] Added packages.irods.org to Dockerfiles

### DIFF
--- a/Dockerfile.irods_core_builder.centos7
+++ b/Dockerfile.irods_core_builder.centos7
@@ -9,7 +9,9 @@ RUN yum update -y && \
                    python python-psutil python-requests python-jsonschema \
                    openssl openssl-devel super lsof postgresql-server unixODBC-devel libjson-perl
 
-RUN rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
+RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
+    wget -qO - https://packages.irods.org/renci-irods.yum.repo | sudo tee /etc/yum.repos.d/renci-irods.yum.repo && \
+    rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
     wget -qO - https://core-dev.irods.org/renci-irods-core-dev.yum.repo | sudo tee /etc/yum.repos.d/renci-irods-core-dev.yum.repo && \
     yum update -y && \
     yum install -y 'irods-externals*'

--- a/Dockerfile.irods_core_builder.ubuntu16
+++ b/Dockerfile.irods_core_builder.ubuntu16
@@ -8,7 +8,9 @@ RUN apt-get update && \
                        python python-psutil python-requests python-jsonschema \
                        libssl-dev super lsof postgresql odbc-postgresql libjson-perl
 
-RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
     apt-get update && \
     apt-get install -y 'irods-externals*'

--- a/Dockerfile.irods_runner.centos7
+++ b/Dockerfile.irods_runner.centos7
@@ -9,10 +9,12 @@ RUN yum update -y && \
                    python python-psutil python-requests python-jsonschema \
                    openssl openssl-devel super lsof postgresql-server unixODBC-devel libjson-perl
 
-RUN rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
+RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
+    wget -qO - https://packages.irods.org/renci-irods.yum.repo | sudo tee /etc/yum.repos.d/renci-irods.yum.repo && \
+    rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
     wget -qO - https://core-dev.irods.org/renci-irods-core-dev.yum.repo | sudo tee /etc/yum.repos.d/renci-irods-core-dev.yum.repo && \
     yum update -y && \
-    yum install -y 'irods-externals*' irods-runtime irods-icommands irods-server irods-database-plugin-postgres
+    yum install -y 'irods-externals*' irods-runtime-4.2.0-1.x86_64 irods-icommands-4.2.0-1.x86_64 irods-server-4.2.0-1.x86_64 irods-database-plugin-postgres-4.2.0-1.x86_64
 
 ADD keep_alive.sh /keep_alive.sh
 RUN chmod +x /keep_alive.sh

--- a/Dockerfile.irods_runner.ubuntu16
+++ b/Dockerfile.irods_runner.ubuntu16
@@ -8,10 +8,12 @@ RUN apt-get update && \
                        python python-psutil python-requests python-jsonschema \
                        libssl-dev super lsof postgresql odbc-postgresql libjson-perl
 
-RUN wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
     apt-get update && \
-    apt-get install -y 'irods-externals*' irods-runtime irods-icommands irods-server irods-database-plugin-postgres
+    apt-get install -y 'irods-externals*' irods-runtime=4.2.2 irods-icommands=4.2.2 irods-server=4.2.2 irods-database-plugin-postgres=4.2.2
 
 ADD keep_alive.sh /keep_alive.sh
 RUN chmod +x /keep_alive.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Prerequisites:
 1. Clone 3 git repositories:
 ```
-$ git clone https://github.com/irods/irods_docker /full/path/to/irods_docker_repository_clone
+$ git clone https://github.com/irods/irods_development_environment /full/path/to/irods_development_environment_repository_clone
 $ git clone --recursive https://github.com/irods/irods /full/path/to/irods_repository_clone
 $ git clone https://github.com/irods/irods_client_icommands /full/path/to/icommands_repository_clone
 ```
@@ -28,8 +28,8 @@ $ docker build -f Dockerfile.irods_runner.centos7 -t irods-runner-centos7 .
 1. Run iRODS Runner container:
 ```
 $ docker run -d --name irods-runner-ubuntu16_whatever \
-            -v /full/path/to/packages_output_dir:/irods_packages:ro \
-            irods-runner-ubuntu16
+             -v /full/path/to/packages_output_dir:/irods_packages:ro \
+             irods-runner-ubuntu16
 ```
 2. Open a shell inside the running container:
 ```
@@ -43,12 +43,12 @@ The usual steps of an initial iRODS installation must be followed on first-time 
 2. Build iRODS and iCommands:
 ```
 $ docker run --rm \
-            -v /full/path/to/irods_repository_clone:/irods_source:ro \
-            -v /full/path/to/irods_build_output_dir:/irods_build \
-            -v /full/path/to/icommands_repository_clone:/icommands_source:ro \
-            -v /full/path/to/icommands_build_output_dir:/icommands_build \
-            -v /full/path/to/packages_output_dir:/irods_packages \
-            irods-core-builder-ubuntu16
+             -v /full/path/to/irods_repository_clone:/irods_source:ro \
+             -v /full/path/to/irods_build_output_dir:/irods_build \
+             -v /full/path/to/icommands_repository_clone:/icommands_source:ro \
+             -v /full/path/to/icommands_build_output_dir:/icommands_build \
+             -v /full/path/to/packages_output_dir:/irods_packages \
+             irods-core-builder-ubuntu16
 ```
 3. Install packages of interest on iRODS Runner (inside iRODS Runner container):
 ```


### PR DESCRIPTION
iRODS runner images launch with the minimum version of iRODS client/server packages installed.
- Ubuntu 16: v4.2.2
- Centos 7: v4.2.0