### PR TITLE
add some options to build script

### DIFF
--- a/Dockerfile.irods_core_builder.centos7
+++ b/Dockerfile.irods_core_builder.centos7
@@ -45,5 +45,5 @@ ENTRYPOINT ["./build_and_copy_packages_to_dir.sh"]
 
 # How to use:
 # ./build_image.sh
-# docker run --rm -v /host/path/to/irods_source:/irods_source -v /host/path/to/irods_build:/irods_build -v /host/path/to/icommands_source:/icommands_source -v /host/path/to/icommands_build:/icommands_build -v /host/path/to/irods_packages:/irods_packages irods_ub16_builder
+# docker run --rm -v /host/path/to/irods_source:/irods_source -v /host/path/to/irods_build:/irods_build -v /host/path/to/icommands_source:/icommands_source -v /host/path/to/icommands_build:/icommands_build -v /host/path/to/irods_packages:/irods_packages irods-core-builder
 

--- a/Dockerfile.irods_core_builder.ubuntu18
+++ b/Dockerfile.irods_core_builder.ubuntu18
@@ -1,10 +1,11 @@
 #
 # iRODS Common
 #
-FROM ubuntu:16.04 as irods_common
+FROM ubuntu:18.04 as irods_common
 
 RUN apt-get update && \
-    apt-get install -y apt-transport-https wget lsb-release sudo \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y apt-transport-https wget lsb-release sudo gnupg \
                        python python-psutil python-requests python-jsonschema \
                        libssl-dev super lsof postgresql odbc-postgresql libjson-perl
 
@@ -13,6 +14,7 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -;
     wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
     apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
     apt-get install -y 'irods-externals*'
 
 #
@@ -22,6 +24,7 @@ FROM irods_common as irods_package_builder_base
 
 # Install iRODS dependencies.
 RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
     apt-get install -y git ninja-build libpam0g-dev unixodbc-dev libkrb5-dev libfuse-dev \
                        libcurl4-gnutls-dev libbz2-dev libxml2-dev zlib1g-dev python-dev \
                        make gcc help2man 

--- a/Dockerfile.irods_runner.ubuntu18
+++ b/Dockerfile.irods_runner.ubuntu18
@@ -1,0 +1,22 @@
+#
+# iRODS Runner
+#
+FROM ubuntu:18.04 as irods-runner
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y apt-transport-https wget lsb-release sudo gnupg \
+                       python python-psutil python-requests python-jsonschema \
+                       libssl-dev super lsof postgresql odbc-postgresql libjson-perl
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y 'irods-externals*' irods-runtime=4.2.8 irods-icommands=4.2.8 irods-server=4.2.8 irods-database-plugin-postgres=4.2.8
+
+ADD keep_alive.sh /keep_alive.sh
+RUN chmod +x /keep_alive.sh
+ENTRYPOINT ["/keep_alive.sh"]

--- a/README.md
+++ b/README.md
@@ -14,14 +14,36 @@ $ mkdir /full/path/to/packages_output_dir
 Note: It may be useful to keep separate build directories across OS flavors in order to ensure
 correctness of builds.
 
-## How to build:
-1. Build the Docker images:
+3. Build the Docker images:
 ```
 $ cd /full/path/to/irods_development_environment_repository_clone
 $ docker build -f Dockerfile.irods_core_builder.ubuntu16 -t irods-core-builder-ubuntu16 .
 $ docker build -f Dockerfile.irods_core_builder.centos7 -t irods-core-builder-centos7 .
 $ docker build -f Dockerfile.irods_runner.ubuntu16 -t irods-runner-ubuntu16 .
 $ docker build -f Dockerfile.irods_runner.centos7 -t irods-runner-centos7 .
+```
+
+## How to build (e.g. Ubuntu 16):
+1. Run iRODS builder container:
+```
+$ docker run --rm \
+             -v /full/path/to/irods_repository_clone:/irods_source:ro \
+             -v /full/path/to/irods_build_output_dir:/irods_build \
+             -v /full/path/to/icommands_repository_clone:/icommands_source:ro \
+             -v /full/path/to/icommands_build_output_dir:/icommands_build \
+             -v /full/path/to/packages_output_dir:/irods_packages \
+             irods-core-builder-ubuntu16
+```
+
+Usage notes (available by running the above with -h):
+```
+Builds iRODS repository, installs the dev/runtime packages, and then builds iCommands
+
+Available options:
+
+    --server-only           Only builds the server
+    -j, --jobs              Number of jobs to use with make
+    -h, --help              This message
 ```
 
 ## How to run (e.g. Ubuntu 16):
@@ -40,19 +62,12 @@ The usual steps of an initial iRODS installation must be followed on first-time 
 
 ## How to develop (e.g. Ubuntu 16):
 1. Edit iRODS/iCommands source files...
-2. Build iRODS and iCommands:
-```
-$ docker run --rm \
-             -v /full/path/to/irods_repository_clone:/irods_source:ro \
-             -v /full/path/to/irods_build_output_dir:/irods_build \
-             -v /full/path/to/icommands_repository_clone:/icommands_source:ro \
-             -v /full/path/to/icommands_build_output_dir:/icommands_build \
-             -v /full/path/to/packages_output_dir:/irods_packages \
-             irods-core-builder-ubuntu16
-```
+2. Build iRODS and iCommands (see "How to build")
 3. Install packages of interest on iRODS Runner (inside iRODS Runner container):
 ```
 root@19b35a476e2d:/# dpkg -i /irods_packages/irods-{package_name(s)}.deb
 ```
 4. Test your changes
 5. Rinse and repeat
+
+It is encouraged to build your own wrapper script with your commonly used volume mounts to make this process easier.

--- a/build_and_copy_packages_to_dir.sh
+++ b/build_and_copy_packages_to_dir.sh
@@ -1,5 +1,18 @@
 #! /bin/bash -e
 
+usage() {
+cat <<_EOF_
+Builds iRODS repository, installs the dev/runtime packages, and then builds iCommands
+
+Available options:
+
+    --server-only           Only builds the server
+    -j, --jobs              Number of jobs to use with make
+    -h, --help              This message
+_EOF_
+    exit
+}
+
 # Detect distribution
 if [ -e /etc/redhat-release ] ; then
     DISTRIBUTION="centos"
@@ -9,10 +22,46 @@ else
     DISTRIBUTION="unknown"
 fi
 
+server_only=0
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --server-only)           server_only=1;;
+        -j|--jobs)               shift; build_jobs=${1};;
+        -h|--help)               usage;;
+    esac
+    shift
+done
+
+echo "========================================="
+echo "beginning build of iRODS server"
+echo "========================================="
+
 # Build iRODS
 mkdir -p /irods_build && cd /irods_build
 cmake /irods_source
-make -j package
+if [[ -z ${build_jobs} ]]; then
+    make -j package
+else
+    echo "using [${build_jobs}] threads"
+    make -j ${build_jobs} package
+fi
+
+# Copy packages to mounts
+if [ "${DISTRIBUTION}" == "centos" ] ; then
+    cp -r /irods_build/*.rpm /irods_packages/
+elif [ "${DISTRIBUTION}" == "debian" ] ; then
+    cp -r /irods_build/*.deb /irods_packages/
+fi
+
+# stop if --server-only option was used
+if [[ ${server_only} -gt 0 ]]; then
+    exit
+fi
+
+echo "========================================="
+echo "beginning build of iCommands"
+echo "========================================="
 
 # Install packages for building iCommands.
 if [ "${DISTRIBUTION}" == "centos" ] ; then
@@ -24,13 +73,16 @@ fi
 # Build icommands
 mkdir -p /icommands_build && cd /icommands_build
 cmake /icommands_source
-make -j package
+if [[ -z ${build_jobs} ]]; then
+    make -j package
+else
+    echo "using [${build_jobs}] threads"
+    make -j ${build_jobs} package
+fi
 
 # Copy packages to mounts
 if [ "${DISTRIBUTION}" == "centos" ] ; then
-    cp -r /irods_build/*.rpm /irods_packages/
     cp -r /icommands_build/*.rpm /irods_packages/
 elif [ "${DISTRIBUTION}" == "debian" ] ; then
-    cp -r /irods_build/*.deb /irods_packages/
     cp -r /icommands_build/*.deb /irods_packages/
 fi

--- a/build_image.sh
+++ b/build_image.sh
@@ -22,7 +22,7 @@ _EOF_
 }
 
 # defaults
-image_name=irods_ub16_builder
+image_name=irods-core-builder
 build_args=
 docker_build_args=
 dockerfile=Dockerfile.ub16


### PR DESCRIPTION
Adds `--jobs`, `--server-only`, and `--help` options to build/copy script. Updated README to reflect new options and make slightly clearer what the steps are