### PR TITLE
[#6] expose --ninja option in top level script

### DIFF
--- a/build_and_copy_packages_to_dir.sh
+++ b/build_and_copy_packages_to_dir.sh
@@ -9,7 +9,7 @@ Available options:
     --server-only           Only builds the server
     -d, --debug             Build with symbols for debugging
     -j, --jobs              Number of jobs for make tool
-    -n, --ninja)            Use ninja builder as the make tool
+    -N, --ninja)            Use ninja builder as the make tool
     -h, --help              This message
 _EOF_
     exit
@@ -33,7 +33,7 @@ debug_config=""
 while [ -n "$1" ]; do
     case "$1" in
         --server-only)           server_only=1;;
-        -n|--ninja)              make_program_config="-GNinja";
+        -N|--ninja)              make_program_config="-GNinja";
                                  make_program="ninja";;
         -j|--jobs)               shift; build_jobs=$(($1 + 0));;
         -d|--debug)              debug_config="-DCMAKE_BUILD_TYPE=Debug";;

--- a/run_debugger.sh
+++ b/run_debugger.sh
@@ -6,6 +6,7 @@ do_source_build="."
 OS_NAME="ubuntu18"
 DEVROOT=""
 NO_CACHE=""
+BUILD_OPTIONS=""
 DOCKER_OPTIONS="
                  -d -i -t "
 DEBUG_OPTIONS="
@@ -41,6 +42,7 @@ while [[ $1 = -* ]]; do
         -s|--skip-source-build) do_source_build="";;
         -n|--no-cache) NO_CACHE="--no-cache";;
         -g|--debug*) do_source_build=".--debug";;
+        -N|--ninja) BUILD_OPTIONS+=" --ninja";;
         *) usage bad option "'$1'" ;;
     esac
     shift
@@ -105,7 +107,7 @@ else
     docker build --build-arg debugger_base=${base_image}  -f Dockerfile.build_debuggers."$OS_NAME" -t debuggers."$OS_NAME" . ${NO_CACHE}
     if [ -n "$do_source_build" ]; then
         docker build -t irods_core_builder."$OS_NAME" -f Dockerfile.irods_core_builder."$OS_NAME" . ${NO_CACHE}
-        docker run "${vol_mounts[@]}" irods_core_builder."$OS_NAME" "${do_source_build:1}"
+        docker run "${vol_mounts[@]}" irods_core_builder."$OS_NAME" ${do_source_build:1} ${BUILD_OPTIONS}
     fi
     docker build --build-arg runner_base=debuggers."$OS_NAME" -t "${IMAGE}" -f Dockerfile.irods_runner."$OS_NAME" . ${NO_CACHE}
     docker run "${vol_mounts[@]}" ${DOCKER_OPTIONS} ${DEBUG_OPTIONS} "${IMAGE}"


### PR DESCRIPTION
This finally addresses #6  by exposing the -N/--ninja option in the master builder/runner/debugger command script ( `run_debugger.sh` )