### PR TITLE
Refactor Dockerfiles to cut down on image size and unnecessary intermediate images

### DIFF
--- a/Dockerfile.build_debuggers.centos7
+++ b/Dockerfile.build_debuggers.centos7
@@ -1,49 +1,166 @@
 ARG debugger_base=centos:7
 FROM ${debugger_base}
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
 ARG parallelism=3
 ARG tools_prefix=/opt/debug_tools
 
 RUN mkdir -p  ${tools_prefix}
 
-RUN yum install -y epel-release sudo wget gcc-c++
-RUN  rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc
-RUN wget -qO - https://core-dev.irods.org/renci-irods-core-dev.yum.repo | tee /etc/yum.repos.d/renci-irods-core-dev.yum.repo
-RUN yum install -y \
-        irods-externals-clang-runtime6.0-0 \
-        irods-externals-clang6.0-0 \
-        irods-externals-cmake3.11.4-0
-RUN yum install -y python3  ccache cmake make gcc gcc-c++ gdb libgcc libgcc.i686 \
-                   glibc-devel glibc-devel.i686 libstdc++-devel libstdc++-devel.i686 \
-                   python-devel  ncurses-devel
-RUN yum install -y capnproto capnproto-devel capnproto-libs ninja-build make git
-RUN sudo pip3 install pexpect
-
-
 WORKDIR /tmp
-RUN git clone http://github.com/mozilla/rr
-RUN cd  rr && git reset --hard 4513b23c8092097dc42c73f3cbaf4cfaebd04efe
 
-RUN mkdir obj
-RUN export LD_LIBRARY_PATH=/opt/irods-externals/clang-runtime6.0-0/lib \
-           LD_RUN_PATH=/opt/irods-externals/clang-runtime6.0-0/lib     \
-           CC=/opt/irods-externals/clang6.0-0/bin/clang \
-           CXX="/opt/irods-externals/clang6.0-0/bin/clang++ -stdlib=libc++" && \
-           cd obj && \
-           /opt/irods-externals/cmake3.11.4-0/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH="${tools_prefix}" ../rr -GNinja && \
-           /opt/irods-externals/cmake3.11.4-0/bin/cmake  --build . --target install
+#--------
+# TODO: Figure out what section these go in
 
-RUN wget http://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.gz
-RUN tar xzf gdb*gz && cd gdb*/ \
-  && ./configure --prefix=${tools_prefix} --with-python --with-curses --enable-tui \
-  && make -j${parallelism}
-RUN yum install -y texinfo
-RUN cd gdb*/ && make install
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    epel-release \
+    sudo \
+    wget \
+    gcc-c++ \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
-RUN wget  https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2
-RUN yum install -y bzip2
-RUN tar xjf valgrind*bz2 && cd valgrind*/ && \
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    python3 \
+    ccache \
+    cmake \
+    make \
+    gcc \
+    gcc-c++ \
+    gdb \
+    libgcc \
+    libgcc.i686 \
+    glibc-devel \
+    glibc-devel.i686 \
+    libstdc++-devel \
+    libstdc++-devel.i686 \
+    python-devel \
+    ncurses-devel \
+    which \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    python3-pip \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN pip3 --no-cache-dir install pexpect
+
+#--------
+# rr
+
+ARG rr_commit="4513b23c8092097dc42c73f3cbaf4cfaebd04efe"
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    capnproto \
+    capnproto-devel \
+    capnproto-libs \
+    ninja-build \
+    make \
+    git \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
+    wget -qO - https://core-dev.irods.org/renci-irods-core-dev.yum.repo | tee /etc/yum.repos.d/renci-irods-core-dev.yum.repo && \
+    yum check-update -y || { rc=$?; [ "$rc" -eq 100 ] && exit 0; exit "$rc"; } && \
+    yum clean all && \
+    rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    irods-externals-clang-runtime6.0-0 \
+    irods-externals-clang6.0-0 \
+    irods-externals-cmake3.11.4-0 \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN git clone http://github.com/mozilla/rr && \
+    cd rr && \
+    { [ -z "${rr_commit}" ] || git checkout "${rr_commit}"; } && \
+    mkdir ../obj && cd ../obj && \
+    export \
+      LD_LIBRARY_PATH=/opt/irods-externals/clang-runtime6.0-0/lib \
+      LD_RUN_PATH=/opt/irods-externals/clang-runtime6.0-0/lib \
+      CC=/opt/irods-externals/clang6.0-0/bin/clang \
+      CXX="/opt/irods-externals/clang6.0-0/bin/clang++ -stdlib=libc++" \
+      CCACHE_DISABLE=1 \
+    && \
+    /opt/irods-externals/cmake3.11.4-0/bin/cmake \
+      -DCMAKE_INSTALL_PREFIX:PATH="${tools_prefix}" \
+      -GNinja \
+      ../rr \
+    && \
+    /opt/irods-externals/cmake3.11.4-0/bin/cmake --build . --target install -- -j${parallelism}
+
+#--------
+# gdb
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    texinfo \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  wget http://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.gz \
+    && tar xzf gdb*.tar.gz \
+    && cd gdb*/ \
+    && export CCACHE_DISABLE=1 \
+    && ./configure --prefix=${tools_prefix} --with-python --with-curses --enable-tui \
+    && make -j${parallelism} \
+    && make install \
+    && cd .. \
+    && rm -rf gdb*.tar.gz gdb*/
+
+#--------
+# valgrind
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    bzip2 \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 && \
+    tar xjf valgrind*tar.bz2 && \
+    cd valgrind*/ && \
+    export CCACHE_DISABLE=1 && \
     ./configure --prefix=${tools_prefix} && \
-    make -j${parallelism} install
+    make -j${parallelism} install && \
+    cd .. && \
+    rm -rf valgrind*tar.bz2 valgrind*/
 
-## optional
-RUN yum install -y nano vim-enhanced tmux tig
+#--------
+# utils
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    nano \
+    vim-enhanced \
+    tmux \
+    tig \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*

--- a/Dockerfile.build_debuggers.ubuntu16
+++ b/Dockerfile.build_debuggers.ubuntu16
@@ -4,45 +4,96 @@ FROM ${debugger_base}
 ARG parallelism=3
 ARG tools_prefix=/opt/debug_tools
 
-RUN apt update
-RUN apt install -y texinfo libncurses5-dev g++ wget make
-RUN apt install -y python-dev
-RUN apt remove  -y python3-dev
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p  ${tools_prefix}
 
 WORKDIR /tmp
 
-RUN wget http://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.gz
+#--------
+# gdb
 
-RUN tar xzf gdb*gz && cd gdb*/ \
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    texinfo \
+    libncurses5-dev \
+    g++ \
+    wget \
+    make \
+    python-dev \
+  && \
+  apt-get remove -y python3-dev && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN \
+  wget http://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.gz \
+    && tar xzf gdb*.tar.gz \
+    && cd gdb*/ \
     && ./configure --prefix=${tools_prefix} --with-python --with-curses --enable-tui \
-    && make -j${parallelism}
-
-RUN cd gdb*/ && make install
+    && make -j${parallelism} \
+    && make install \
+    && cd .. \
+    && rm -rf gdb*.tar.gz gdb*/
 
 #--------
+# rr
 
 ARG rr_commit="4513b23c8092097dc42c73f3cbaf4cfaebd04efe"
 
-RUN apt-get install -y ccache cmake make g++-multilib gdb pkg-config \
-      coreutils python3-pexpect manpages-dev git ninja-build capnproto \
-      libcapnp-dev
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    ccache \
+    cmake \
+    g++-multilib \
+    gdb \
+    pkg-config \
+    coreutils \
+    python3-pexpect \
+    manpages-dev \
+    git \
+    ninja-build \
+    capnproto \
+    libcapnp-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN git clone http://github.com/mozilla/rr
-
-RUN cd rr && \
+RUN git clone http://github.com/mozilla/rr && \
+    cd rr && \
     { [ -z "${rr_commit}" ] || git checkout "${rr_commit}"; } && \
     mkdir ../obj && cd ../obj && \
-    cmake ../rr \
-    -DCMAKE_INSTALL_PREFIX:PATH=${tools_prefix} && \
+    export CCACHE_DISABLE=1 && \
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=${tools_prefix} ../rr && \
     make -j${parallelism} && \
-    make install
+    make install && \
+    cd .. && \
+    rm -rf obj rr
 
-RUN wget  https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2
+#--------
+# valgrind
 
-RUN tar xjf valgrind*bz2 && cd valgrind*/ && \
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 && \
+    tar xjf valgrind*tar.bz2 && \
+    cd valgrind*/ && \
+    export CCACHE_DISABLE=1 && \
     ./configure --prefix=${tools_prefix} && \
-    make -j${parallelism} install
+    make -j${parallelism} install && \
+    cd .. && \
+    rm -rf valgrind*tar.bz2 valgrind*/
 
-RUN apt install -y tmux vim nano tig
+#--------
+# utils
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    tmux \
+    vim \
+    nano \
+    tig \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*

--- a/Dockerfile.build_debuggers.ubuntu18
+++ b/Dockerfile.build_debuggers.ubuntu18
@@ -4,45 +4,96 @@ FROM ${debugger_base}
 ARG parallelism=3
 ARG tools_prefix=/opt/debug_tools
 
-RUN apt update
-RUN apt install -y texinfo libncurses5-dev g++ wget make
-RUN apt install -y python-dev
-RUN apt remove  -y python3-dev
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p  ${tools_prefix}
 
 WORKDIR /tmp
 
-RUN wget http://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.gz
+#--------
+# gdb
 
-RUN tar xzf gdb*gz && cd gdb*/ \
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    texinfo \
+    libncurses5-dev \
+    g++ \
+    wget \
+    make \
+    python-dev \
+  && \
+  apt-get remove -y python3-dev && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN \
+  wget http://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.gz \
+    && tar xzf gdb*.tar.gz \
+    && cd gdb*/ \
     && ./configure --prefix=${tools_prefix} --with-python --with-curses --enable-tui \
-    && make -j${parallelism}
-
-RUN cd gdb*/ && make install
+    && make -j${parallelism} \
+    && make install \
+    && cd .. \
+    && rm -rf gdb*.tar.gz gdb*/
 
 #--------
+# rr
 
 ARG rr_commit="4513b23c8092097dc42c73f3cbaf4cfaebd04efe"
 
-RUN apt-get install -y ccache cmake make g++-multilib gdb pkg-config \
-      coreutils python3-pexpect manpages-dev git ninja-build capnproto \
-      libcapnp-dev
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    ccache \
+    cmake \
+    g++-multilib \
+    gdb \
+    pkg-config \
+    coreutils \
+    python3-pexpect \
+    manpages-dev \
+    git \
+    ninja-build \
+    capnproto \
+    libcapnp-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN git clone http://github.com/mozilla/rr
-
-RUN cd rr && \
+RUN git clone http://github.com/mozilla/rr && \
+    cd rr && \
     { [ -z "${rr_commit}" ] || git checkout "${rr_commit}"; } && \
     mkdir ../obj && cd ../obj && \
-    cmake ../rr \
-    -DCMAKE_INSTALL_PREFIX:PATH=${tools_prefix} && \
+    export CCACHE_DISABLE=1 && \
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=${tools_prefix} ../rr && \
     make -j${parallelism} && \
-    make install
+    make install && \
+    cd .. && \
+    rm -rf obj rr
 
-RUN wget  https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2
+#--------
+# valgrind
 
-RUN tar xjf valgrind*bz2 && cd valgrind*/ && \
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 && \
+    tar xjf valgrind*tar.bz2 && \
+    cd valgrind*/ && \
+    export CCACHE_DISABLE=1 && \
     ./configure --prefix=${tools_prefix} && \
-    make -j${parallelism} install
+    make -j${parallelism} install && \
+    cd .. && \
+    rm -rf valgrind*tar.bz2 valgrind*/
 
-RUN apt install -y tmux vim nano tig
+#--------
+# utils
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    tmux \
+    vim \
+    nano \
+    tig \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*

--- a/Dockerfile.irods_core_builder.centos7
+++ b/Dockerfile.irods_core_builder.centos7
@@ -3,18 +3,51 @@
 #
 FROM centos:7 as irods_common
 
-RUN yum update -y && \
-    yum install -y epel-release && \
-    yum install -y wget sudo \
-                   python python-psutil python-requests python-jsonschema \
-                   openssl openssl-devel super lsof postgresql-server unixODBC-devel libjson-perl
+SHELL [ "/usr/bin/bash", "-c" ]
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    epel-release \
+    sudo \
+    wget \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    python \
+    python2-psutil \
+    python-requests \
+    python2-jsonschema \
+    openssl \
+    openssl-devel \
+    super \
+    lsof \
+    postgresql-server \
+    unixODBC-devel \
+    libjson-perl \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
     wget -qO - https://packages.irods.org/renci-irods.yum.repo | sudo tee /etc/yum.repos.d/renci-irods.yum.repo && \
     rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
     wget -qO - https://core-dev.irods.org/renci-irods-core-dev.yum.repo | sudo tee /etc/yum.repos.d/renci-irods-core-dev.yum.repo && \
-    yum update -y && \
-    yum install -y 'irods-externals*'
+    yum check-update -y || { rc=$?; [ "$rc" -eq 100 ] && exit 0; exit "$rc"; } && \
+    yum clean all && \
+    rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    'irods-externals*' \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 #
 # iRODS Packages Builder Base Image
@@ -22,10 +55,27 @@ RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
 FROM irods_common as irods_package_builder_base
 
 # Install iRODS dependencies.
-RUN yum update -y && \
-    yum install -y git ninja-build pam-devel krb5-devel fuse-devel which \
-                   libcurl-devel bzip2-devel libxml2-devel zlib-devel python-devel \
-                   make gcc-c++ help2man rpm-build
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    git \
+    ninja-build \
+    pam-devel \
+    krb5-devel \
+    fuse-devel \
+    which \
+    libcurl-devel \
+    bzip2-devel \
+    libxml2-devel \
+    zlib-devel \
+    python-devel \
+    make \
+    gcc-c++ \
+    help2man \
+    rpm-build \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 #
 # iRODS Packages Builder Image

--- a/Dockerfile.irods_core_builder.ubuntu16
+++ b/Dockerfile.irods_core_builder.ubuntu16
@@ -3,17 +3,41 @@
 #
 FROM ubuntu:16.04 as irods_common
 
-RUN apt-get update && \
-    apt-get install -y apt-transport-https wget lsb-release sudo \
-                       python python-psutil python-requests python-jsonschema \
-                       libssl-dev super lsof postgresql odbc-postgresql libjson-perl
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
-    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
-    apt-get update && \
-    apt-get install -y 'irods-externals*'
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    apt-transport-https \
+    wget \
+    lsb-release \
+    sudo \
+    python \
+    python-psutil \
+    python-requests \
+    python-jsonschema \
+    libssl-dev \
+    super \
+    lsof \
+    postgresql \
+    odbc-postgresql \
+    libjson-perl \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    'irods-externals*' \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
 #
 # iRODS Packages Builder Base Image
@@ -21,10 +45,26 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -;
 FROM irods_common as irods_package_builder_base
 
 # Install iRODS dependencies.
-RUN apt-get update && \
-    apt-get install -y git ninja-build libpam0g-dev unixodbc-dev libkrb5-dev libfuse-dev \
-                       libcurl4-gnutls-dev libbz2-dev libxml2-dev zlib1g-dev python-dev \
-                       make gcc help2man 
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    git \
+    ninja-build \
+    libpam0g-dev \
+    unixodbc-dev \
+    libkrb5-dev \
+    libfuse-dev \
+    libcurl4-gnutls-dev \
+    libbz2-dev \
+    libxml2-dev \
+    zlib1g-dev \
+    python-dev \
+    make \
+    gcc \
+    help2man \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
 #
 # iRODS Packages Builder Image

--- a/Dockerfile.irods_core_builder.ubuntu18
+++ b/Dockerfile.irods_core_builder.ubuntu18
@@ -3,19 +3,42 @@
 #
 FROM ubuntu:18.04 as irods_common
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y apt-transport-https wget lsb-release sudo gnupg \
-                       python python-psutil python-requests python-jsonschema \
-                       libssl-dev super lsof postgresql odbc-postgresql libjson-perl
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
-    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y 'irods-externals*'
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    apt-transport-https \
+    wget \
+    lsb-release \
+    sudo \
+    gnupg \
+    python \
+    python-psutil \
+    python-requests \
+    python-jsonschema \
+    libssl-dev \
+    super \
+    lsof \
+    postgresql \
+    odbc-postgresql \
+    libjson-perl \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    'irods-externals*' \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
 #
 # iRODS Packages Builder Base Image
@@ -23,11 +46,26 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -;
 FROM irods_common as irods_package_builder_base
 
 # Install iRODS dependencies.
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y git ninja-build libpam0g-dev unixodbc-dev libkrb5-dev libfuse-dev \
-                       libcurl4-gnutls-dev libbz2-dev libxml2-dev zlib1g-dev python-dev \
-                       make gcc help2man 
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    git \
+    ninja-build \
+    libpam0g-dev \
+    unixodbc-dev \
+    libkrb5-dev \
+    libfuse-dev \
+    libcurl4-gnutls-dev \
+    libbz2-dev \
+    libxml2-dev \
+    zlib1g-dev \
+    python-dev \
+    make \
+    gcc \
+    help2man \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
 #
 # iRODS Packages Builder Image

--- a/Dockerfile.irods_runner.centos7
+++ b/Dockerfile.irods_runner.centos7
@@ -4,18 +4,54 @@
 ARG runner_base=centos:7
 FROM ${runner_base} as irods-runner
 
-RUN yum update -y && \
-    yum install -y epel-release && \
-    yum install -y wget sudo rsyslog \
-                   python python-psutil python-requests python-jsonschema \
-                   openssl openssl-devel super lsof postgresql-server unixODBC-devel libjson-perl
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    epel-release \
+    sudo \
+    wget \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    rsyslog \
+    python \
+    python2-psutil \
+    python-requests \
+    python2-jsonschema \
+    openssl \
+    openssl-devel \
+    super \
+    lsof \
+    postgresql-server \
+    unixODBC-devel \
+    libjson-perl \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
     wget -qO - https://packages.irods.org/renci-irods.yum.repo | sudo tee /etc/yum.repos.d/renci-irods.yum.repo && \
     rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
     wget -qO - https://core-dev.irods.org/renci-irods-core-dev.yum.repo | sudo tee /etc/yum.repos.d/renci-irods-core-dev.yum.repo && \
-    yum update -y && \
-    yum install -y 'irods-externals*' irods-runtime-4.2.0-1.x86_64 irods-icommands-4.2.0-1.x86_64 irods-server-4.2.0-1.x86_64 irods-database-plugin-postgres-4.2.0-1.x86_64
+    yum check-update -y || { rc=$?; [ "$rc" -eq 100 ] && exit 0; exit "$rc"; } && \
+    yum clean all && \
+    rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  yum check-update || [ "$?" -eq 100 ] && \
+  yum install -y \
+    'irods-externals*' \
+    irods-runtime-4.2.0-1.x86_64 \
+    irods-icommands-4.2.0-1.x86_64 \
+    irods-server-4.2.0-1.x86_64 \
+    irods-database-plugin-postgres-4.2.0-1.x86_64 \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
 
 ADD ICAT.sql /
 ADD keep_alive.sh /keep_alive.sh

--- a/Dockerfile.irods_runner.ubuntu16
+++ b/Dockerfile.irods_runner.ubuntu16
@@ -4,18 +4,48 @@
 ARG runner_base=ubuntu:16.04
 FROM ${runner_base} as irods-runner
 
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y apt-transport-https wget lsb-release sudo gnupg rsyslog \
-                       python python-psutil python-requests python-jsonschema \
-                       libssl-dev super lsof postgresql odbc-postgresql libjson-perl
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    apt-transport-https \
+    wget \
+    lsb-release \
+    sudo \
+    gnupg \
+    rsyslog \
+    python \
+    python-psutil \
+    python3-psutil \
+    python-requests \
+    python-jsonschema \
+    libssl-dev \
+    super \
+    lsof \
+    postgresql \
+    odbc-postgresql \
+    libjson-perl \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
-    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
-    apt-get update && \
-    apt-get install -y 'irods-externals*' irods-runtime=4.2.2 irods-icommands=4.2.2 irods-server=4.2.2 irods-database-plugin-postgres=4.2.2
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    'irods-externals*' \
+    irods-runtime=4.2.2 \
+    irods-icommands=4.2.2 \
+    irods-server=4.2.2 \
+    irods-database-plugin-postgres=4.2.2 \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
 ADD ICAT.sql /
 ADD keep_alive.sh /keep_alive.sh

--- a/Dockerfile.irods_runner.ubuntu18
+++ b/Dockerfile.irods_runner.ubuntu18
@@ -4,21 +4,59 @@
 ARG runner_base=ubuntu:18.04
 FROM ${runner_base} as irods-runner
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y apt-transport-https wget lsb-release sudo gnupg rsyslog \
-                       python python-psutil python-requests python-jsonschema \
-                       libssl-dev super lsof postgresql odbc-postgresql libjson-perl
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get install -y git vim nano rsyslog
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    apt-transport-https \
+    wget \
+    lsb-release \
+    sudo \
+    gnupg \
+    rsyslog \
+    python \
+    python-psutil \
+    python3-psutil \
+    python-requests \
+    python-jsonschema \
+    libssl-dev \
+    super \
+    lsof \
+    postgresql \
+    odbc-postgresql \
+    libjson-perl \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
-    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add -; \
-    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list; \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y 'irods-externals*' irods-runtime=4.2.8 irods-icommands=4.2.8 irods-server=4.2.8 irods-database-plugin-postgres=4.2.8
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    git \
+    vim \
+    nano \
+    rsyslog \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
+
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    'irods-externals*' \
+    irods-runtime=4.2.8 \
+    irods-icommands=4.2.8 \
+    irods-server=4.2.8 \
+    irods-database-plugin-postgres=4.2.8 \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
 
 ADD ICAT.sql /
 ADD keep_alive.sh /keep_alive.sh


### PR DESCRIPTION
The size and quantity of docker images on my system was bothering me, so I've refactored the Dockerfiles to cut down on image size and unnecessary cache boundaries/intermediate images.
I'm not super familiar with centos, but I did my best to give the centos7 Dockerfiles the same treatment.

Apologies for the ugly diff.