### PR TITLE
24.m

### DIFF
--- a/Dockerfile.build_debuggers.centos7
+++ b/Dockerfile.build_debuggers.centos7
@@ -14,7 +14,7 @@ WORKDIR /tmp
 # TODO: Figure out what section these go in
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     epel-release \
     sudo \
@@ -25,7 +25,7 @@ RUN \
   rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     python3 \
     ccache \
@@ -48,7 +48,7 @@ RUN \
   rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     python3-pip \
   && \
@@ -63,7 +63,7 @@ RUN pip3 --no-cache-dir install pexpect
 ARG rr_commit="4513b23c8092097dc42c73f3cbaf4cfaebd04efe"
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     capnproto \
     capnproto-devel \
@@ -82,7 +82,7 @@ RUN rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
     rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     irods-externals-clang-runtime6.0-0 \
     irods-externals-clang6.0-0 \
@@ -113,7 +113,7 @@ RUN git clone http://github.com/mozilla/rr && \
 # gdb
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     texinfo \
   && \
@@ -135,7 +135,7 @@ RUN \
 # valgrind
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     bzip2 \
   && \
@@ -155,7 +155,7 @@ RUN wget https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 && \
 # utils
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     nano \
     vim-enhanced \

--- a/Dockerfile.build_debuggers.centos7
+++ b/Dockerfile.build_debuggers.centos7
@@ -104,7 +104,6 @@ RUN git clone http://github.com/mozilla/rr && \
     && \
     /opt/irods-externals/cmake3.11.4-0/bin/cmake \
       -DCMAKE_INSTALL_PREFIX:PATH="${tools_prefix}" \
-      -GNinja \
       ../rr \
     && \
     /opt/irods-externals/cmake3.11.4-0/bin/cmake --build . --target install -- -j${parallelism}

--- a/Dockerfile.irods_core_builder.centos7
+++ b/Dockerfile.irods_core_builder.centos7
@@ -6,7 +6,7 @@ FROM centos:7 as irods_common
 SHELL [ "/usr/bin/bash", "-c" ]
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     epel-release \
     sudo \
@@ -16,7 +16,7 @@ RUN \
   rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     python \
     python2-psutil \
@@ -42,7 +42,7 @@ RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
     rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     'irods-externals*' \
   && \
@@ -56,7 +56,7 @@ FROM irods_common as irods_package_builder_base
 
 # Install iRODS dependencies.
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     git \
     ninja-build \

--- a/Dockerfile.irods_runner.centos7
+++ b/Dockerfile.irods_runner.centos7
@@ -5,7 +5,7 @@ ARG runner_base=centos:7
 FROM ${runner_base} as irods-runner
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     epel-release \
     sudo \
@@ -15,7 +15,7 @@ RUN \
   rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     rsyslog \
     python \
@@ -42,7 +42,7 @@ RUN rpm --import https://packages.irods.org/irods-signing-key.asc && \
     rm -rf /var/cache/yum /tmp/*
 
 RUN \
-  yum check-update || [ "$?" -eq 100 ] && \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
   yum install -y \
     'irods-externals*' \
     irods-runtime-4.2.0-1.x86_64 \


### PR DESCRIPTION
All **centos7** Docker files were  potentially affected , so I slightly altered the logic of `yum check-update` & added ` yum update` in each such line to ensure ca-certificates (and other things) are up-to-date.

For rr, we'll now use make instead of ninja to allow debugger tools to build as ninja gets confused , resulting in: "multiple rules generating" the same target. (Also affected centos 7 only, `rr` on ubuntu\* debugger tools images were building with make already.)

Tested manually.  