### PR TITLE
Add iRODS plugin builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,3 +266,26 @@ The clang static analyzer can be used when building iRODS.
    cmake -DCLANG_STATIC_ANALYZER=ON -GNinja ..
    scan-build ninja
    ```
+
+## How to Build an iRODS Plugin
+
+The plugin builder functions very similarly to the core builder.
+
+In addition to the build and package volume mounts, there also needs to be a volume mount for iRODS core packages (i.e. irods-dev and irods-runtime) so that the plugin can install dependencies.
+
+Build the plugin builder like this (use whatever image tag that you wish):
+```bash
+docker build -f plugin_builder.ubuntu16.Dockerfile -t irods-plugin-builder:ubuntu-16.04 .
+docker build -f plugin_builder.ubuntu18.Dockerfile -t irods-plugin-builder:ubuntu-18.04 .
+docker build -f plugin_builder.centos7.Dockerfile -t irods-plugin-builder:centos-7 .
+```
+
+And run the plugin builder like this, e.g. ubuntu:16.04:
+```bash
+docker run --rm \
+           -v /full/path/to/irods_plugin_repository_clone:/irods_plugin_source \
+           -v /full/path/to/plugin_build_output_dir:/irods_plugin_build \
+           -v /full/path/to/plugin_packages_output_dir:/irods_plugin_packages \
+           -v /full/path/to/built_irods_packages_dir:/irods_packages \
+           irods-plugin-builder:ubuntu-16.04 --build_directory /irods_plugin_build
+```

--- a/build_and_copy_plugin_packages_to_dir.sh
+++ b/build_and_copy_plugin_packages_to_dir.sh
@@ -1,0 +1,21 @@
+#! /bin/bash -e
+
+# Detect distribution
+if [ -e /etc/redhat-release ] ; then
+    DISTRIBUTION="centos"
+elif [ -e /etc/lsb-release ] ; then
+    DISTRIBUTION="debian"
+else
+    DISTRIBUTION="unknown"
+fi
+
+# Build iRODS
+python /irods_plugin_source/irods_consortium_continuous_integration_build_hook.py \
+    --irods_packages_root_directory /irods_packages $@
+
+# Copy packages to mounts
+if [ "${DISTRIBUTION}" == "centos" ] ; then
+    cp -r /irods_plugin_build/*.rpm /irods_plugin_packages/
+elif [ "${DISTRIBUTION}" == "debian" ] ; then
+    cp -r /irods_plugin_build/*.deb /irods_plugin_packages/
+fi

--- a/plugin_builder.centos7.Dockerfile
+++ b/plugin_builder.centos7.Dockerfile
@@ -1,0 +1,32 @@
+FROM centos:7
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
+RUN \
+  yum check-update -q >/dev/null || { [ "$?" -eq 100 ] && yum update -y; } && \
+  yum install -y \
+    epel-release \
+    sudo \
+    wget \
+    git \
+    python \
+    python-pip \
+    rpm-build \
+    gcc-c++ \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN yum install -y python-pip && \
+    pip install --upgrade 'pip<21.0' \
+  && \
+  yum clean all && \
+  rm -rf /var/cache/yum /tmp/*
+
+RUN \
+  git clone https://github.com/irods/irods_python_ci_utilities && \
+  pip install -e /irods_python_ci_utilities
+
+COPY build_and_copy_plugin_packages_to_dir.sh /
+RUN chmod u+x /build_and_copy_plugin_packages_to_dir.sh
+ENTRYPOINT ["./build_and_copy_plugin_packages_to_dir.sh"]

--- a/plugin_builder.ubuntu16.Dockerfile
+++ b/plugin_builder.ubuntu16.Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+  apt-get update && \
+  apt-get install --no-install-recommends -y \
+    git \
+    python \
+    python-pip \
+    python-setuptools \
+    wget \
+    sudo \
+    lsb-release \
+    gdebi \
+    apt-utils \
+    gnupg \
+    libxml2-dev \
+    apt-transport-https \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN \
+  git clone https://github.com/irods/irods_python_ci_utilities && \
+  pip install -e /irods_python_ci_utilities
+
+COPY build_and_copy_plugin_packages_to_dir.sh /
+RUN chmod u+x /build_and_copy_plugin_packages_to_dir.sh
+ENTRYPOINT ["./build_and_copy_plugin_packages_to_dir.sh"]

--- a/plugin_builder.ubuntu18.Dockerfile
+++ b/plugin_builder.ubuntu18.Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+  apt-get update && \
+  apt-get install --no-install-recommends -y \
+    git \
+    python \
+    python-pip \
+    python-setuptools \
+    wget \
+    sudo \
+    lsb-release \
+    gdebi \
+    apt-utils \
+    gnupg \
+    libxml2-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN \
+  git clone https://github.com/irods/irods_python_ci_utilities && \
+  pip install -e /irods_python_ci_utilities
+
+COPY build_and_copy_plugin_packages_to_dir.sh /
+RUN chmod u+x /build_and_copy_plugin_packages_to_dir.sh
+ENTRYPOINT ["./build_and_copy_plugin_packages_to_dir.sh"]


### PR DESCRIPTION
Still tinkering with this, but seems to be working with PREP. See irods/irods_rule_engine_plugin_python#89 for build directory option. I want to add the packages installed by the build hooks to the Docker image itself so it doesn't have to install them every time, but that might need to be a next step as there are many packages.