### PR TITLE
enable powertools in almalinux for plugin builds

### DIFF
--- a/plugin_builder.almalinux8.Dockerfile
+++ b/plugin_builder.almalinux8.Dockerfile
@@ -27,11 +27,13 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     --mount=type=cache,target=/root/.cache/wheel,sharing=locked \
     dnf install -y \
+        dnf-plugins-core \
         python3 \
         python3-devel \
         python3-pip \
     && \
     python3 -m pip install --upgrade 'pip<21.0' && \
+    dnf config-manager --set-enabled powertools && \
     rm -rf /tmp/*
 
 # TODO: python3 is the only option at this time, so we don't really need this


### PR DESCRIPTION
https://github.com/irods/irods_netcdf/issues/25 is related but this requirement may apply in a broader way whenever a plugin depends on system libraries (ie build and runtime prerequisites other than irods-externals)