### PR TITLE
Add preliminary Dockerfiles for Rocky Linux 9 and Debian 12

### DIFF
--- a/build_debuggers.debian12.Dockerfile
+++ b/build_debuggers.debian12.Dockerfile
@@ -1,0 +1,110 @@
+# syntax=docker/dockerfile:1.5
+
+ARG debugger_base=debian:12
+FROM ${debugger_base}
+
+SHELL [ "/bin/bash", "-c" ]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+ARG parallelism=3
+ARG tools_prefix=/opt/debug_tools
+
+RUN mkdir -p  ${tools_prefix}
+
+WORKDIR /tmp
+
+#--------
+# gdb
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        gdb \
+        gdbserver \
+    && \
+    apt-get remove -y python3-dev && \
+    rm -rf /tmp/*
+
+#--------
+# rr
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        python3-urllib3 \
+        binutils \
+        wget \
+    && \
+    rm -rf /tmp/*
+
+ARG rr_version="5.6.0"
+
+RUN wget "https://github.com/rr-debugger/rr/releases/download/${rr_version}/rr-${rr_version}-Linux-x86_64.deb" && \
+    dpkg -i "rr-${rr_version}-Linux-x86_64.deb" && \
+    rm -rf /tmp/*
+
+#--------
+# valgrind
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        valgrind \
+    && \
+    rm -rf /tmp/*
+
+#--------
+# lldb
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        lldb \
+    && \
+    rm -rf /tmp/*
+
+#--------
+# xmlrunner
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        python3-xmlrunner \
+    && \
+    rm -rf /tmp/*
+
+#--------
+# utils
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        tmux \
+        vim \
+        nano \
+        tig \
+        coreutils \
+        python3-pexpect \
+        iproute2 \
+    && \
+    rm -rf /tmp/*

--- a/build_debuggers.rocky9.Dockerfile
+++ b/build_debuggers.rocky9.Dockerfile
@@ -1,0 +1,90 @@
+# syntax=docker/dockerfile:1.5
+
+ARG debugger_base=rockylinux:9
+FROM ${debugger_base}
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf update -y || [ "$?" -eq 100 ] && \
+    rm -rf /tmp/*
+
+ARG parallelism=3
+ARG tools_prefix=/opt/debug_tools
+
+RUN mkdir -p  ${tools_prefix}
+
+WORKDIR /tmp
+
+#--------
+# valgrind, gdb
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y gcc-toolset-12 && \
+    echo "#!/bin/sh" > /etc/profile.d/gcc-toolset-12.sh && \
+    echo "" >> /etc/profile.d/gcc-toolset-12.sh && \
+    echo ". /opt/rh/gcc-toolset-12/enable" >> /etc/profile.d/gcc-toolset-12.sh && \
+    rm -rf /tmp/*
+
+#--------
+# lldb
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y lldb && \
+    rm -rf /tmp/*
+
+#--------
+# rr
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        python3-urllib3 \
+        binutils \
+    && \
+    rm -rf /tmp/*
+
+ARG rr_version="5.6.0"
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y "https://github.com/rr-debugger/rr/releases/download/${rr_version}/rr-${rr_version}-Linux-x86_64.rpm" && \
+    rm -rf /tmp/*
+
+#--------
+# xmlrunner
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        python3-pip \
+    && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    --mount=type=cache,target=/root/.cache/wheel,sharing=locked \
+    python3 -m pip install \
+        xmlrunner \
+    && \
+    rm -rf /tmp/*
+
+#--------
+# utils
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        sudo \
+        nano \
+        vim-enhanced \
+        tmux \
+        lsof \
+        which \
+        file \
+        iproute \
+    && \
+    rm -rf /tmp/*

--- a/externals_builder.debian12.Dockerfile
+++ b/externals_builder.debian12.Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.5
+
+FROM debian:12
+
+SHELL [ "/bin/bash", "-c" ]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        sudo \
+        git \
+        python3 \
+        python3-distro \
+    && \
+    rm -rf /tmp/*
+
+ARG externals_repo="https://github.com/irods/externals"
+ARG externals_branch="main"
+
+WORKDIR /externals
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    git clone "${externals_repo}" -b "${externals_branch}" /externals && \
+    ./install_prerequisites.py && \
+    rm -rf /externals /tmp/*
+
+ENV file_extension="deb"
+ENV package_manager="apt-get"
+
+WORKDIR /
+COPY --chmod=755 build_and_copy_externals_to_dir.sh /
+ENTRYPOINT ["./build_and_copy_externals_to_dir.sh"]

--- a/externals_builder.rocky9.Dockerfile
+++ b/externals_builder.rocky9.Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.5
+
+FROM rockylinux:9
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf update -y || [ "$?" -eq 100 ] && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        sudo \
+        git \
+        python3 \
+        python3-distro \
+        gcc-toolset-12 \
+    && \
+    rm -rf /tmp/*
+
+ARG externals_repo="https://github.com/irods/externals"
+ARG externals_branch="main"
+
+WORKDIR /externals
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    git clone "${externals_repo}" -b "${externals_branch}" /externals && \
+    python3 -m venv build_env && \
+    source build_env/bin/activate && \
+    ./install_prerequisites.py && \
+    rm -rf /externals /tmp/*
+
+# TODO: The following will enable the newer toolchain on interactive shell logins. The
+# externals builder, however, is not an interactive shell, so this does not execute. This seems
+# like a much better option than explicitly setting the PATH environment variable to check for
+# new thing, as is being done below. Investigate making this effective for this builder.
+#RUN echo "#!/bin/sh" > /etc/profile.d/gcc-toolset-12.sh && \
+#    echo "" >> /etc/profile.d/gcc-toolset-12.sh && \
+#    echo ". /opt/rh/gcc-toolset-12/enable" >> /etc/profile.d/gcc-toolset-12.sh
+
+ENV PATH=/opt/rh/gcc-toolset-12/root/usr/bin:$PATH
+
+ENV file_extension="rpm"
+ENV package_manager="dnf"
+
+WORKDIR /
+COPY --chmod=755 build_and_copy_externals_to_dir.sh /
+ENTRYPOINT ["./build_and_copy_externals_to_dir.sh"]

--- a/irods_core_builder.debian12.Dockerfile
+++ b/irods_core_builder.debian12.Dockerfile
@@ -1,0 +1,107 @@
+# syntax=docker/dockerfile:1.5
+
+FROM debian:12
+
+SHELL [ "/bin/bash", "-c" ]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        apt-transport-https \
+        ccache \
+        g++-12 \
+        gcc \
+        gcc-12 \
+        git \
+        gnupg \
+        help2man \
+        libbz2-dev \
+        libcurl4-gnutls-dev \
+        libfuse-dev \
+        libjson-perl \
+        libkrb5-dev \
+        libpam0g-dev \
+        libssl-dev \
+        libxml2-dev \
+        lsb-release \
+        lsof \
+        make \
+        ninja-build \
+        odbc-postgresql \
+        postgresql \
+        python3 \
+        python3-dev \
+        python3-distro \
+        python3-jsonschema \
+        python3-packaging \
+        python3-psutil \
+        python3-pyodbc \
+        python3-requests \
+        sudo \
+        super \
+        unixodbc-dev \
+        wget \
+        zlib1g-dev \
+    && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    --mount=type=cache,target=/root/.cache/wheel,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        python3-pip \
+    && \
+    pip3 install --break-system-packages lief && \
+    rm -rf /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        'irods-externals*' \
+    && \
+    rm -rf /tmp/*
+
+RUN update-alternatives --install /usr/local/bin/gcc gcc /usr/bin/gcc-12 1 && \
+    update-alternatives --install /usr/local/bin/g++ g++ /usr/bin/g++-12 1 && \
+    hash -r
+
+ARG cmake_path="/opt/irods-externals/cmake3.21.4-0/bin"
+ENV PATH ${cmake_path}:$PATH
+
+ENV file_extension "deb"
+ENV package_manager "apt-get"
+
+ENV CCACHE_DIR="/irods_build_cache"
+# Default to a reasonably large cache size
+ENV CCACHE_MAXSIZE="64G"
+# Allow for a lot of files (1.5M files, 300 per directory)
+ENV CCACHE_NLEVELS="3"
+# Allow any uid to use cache
+ENV CCACHE_UMASK="000"
+
+COPY --chmod=755 build_and_copy_packages_to_dir.sh /
+ENTRYPOINT ["./build_and_copy_packages_to_dir.sh"]

--- a/irods_core_builder.rocky9.Dockerfile
+++ b/irods_core_builder.rocky9.Dockerfile
@@ -1,0 +1,126 @@
+# syntax=docker/dockerfile:1.5
+
+FROM rockylinux:9
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf update -y || [ "$?" -eq 100 ] && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        epel-release \
+        wget \
+    && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        ccache \
+        python3-devel \
+        python3-distro \
+        python3-jsonschema \
+        python3-psutil \
+        python3-pyodbc \
+        python3-requests \
+        openssl \
+        openssl-devel \
+        lsof \
+        postgresql-server \
+        which \
+    && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        dnf-plugin-config-manager \
+    && \
+    rpm --import https://packages.irods.org/irods-signing-key.asc && \
+    dnf config-manager -y --add-repo https://packages.irods.org/renci-irods.yum.repo && \
+    dnf config-manager -y --set-enabled renci-irods && \
+    rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
+    dnf config-manager -y --add-repo https://core-dev.irods.org/renci-irods-core-dev.yum.repo && \
+    dnf config-manager -y --set-enabled renci-irods-core-dev && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        'irods-externals*' \
+    && \
+    rm -rf /tmp/*
+
+# For rocky linux, the crb repository should be enabled so that certain developer
+# tools such as ninja-build and help2man can be installed.
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        dnf-plugins-core \
+    && \
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y \
+        git \
+        pam-devel \
+        fuse-devel \
+        libcurl-devel \
+        bzip2-devel \
+        libxml2-devel \
+        make \
+        gcc \
+        gcc-c++ \
+        rpm-build \
+        sudo \
+        ninja-build \
+        help2man \
+        python3-packaging \
+        unixODBC-devel \
+    && \
+    rm -rf /tmp/*
+
+# For Python3 modules not available as packages:
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    --mount=type=cache,target=/root/.cache/wheel,sharing=locked \
+    dnf install -y \
+        python3-pip \
+        cmake \
+        spdlog-devel \
+    && \
+    python3 -m pip install \
+        lief \
+            --global-option="--lief-no-cache" \
+            --global-option="--ninja" \
+            --global-option="--lief-no-pe" \
+            --global-option="--lief-no-macho" \
+            --global-option="--lief-no-android" \
+            --global-option="--lief-no-art" \
+            --global-option="--lief-no-vdex" \
+            --global-option="--lief-no-oat" \
+            --global-option="--lief-no-dex" \
+    && \
+    rm -rf /tmp/*
+
+ARG cmake_path="/opt/irods-externals/cmake3.21.4-0/bin"
+ENV PATH=${cmake_path}:$PATH
+
+ENV file_extension="rpm"
+ENV package_manager="dnf"
+
+ENV CCACHE_DIR="/irods_build_cache"
+# Default to a reasonably large cache size
+ENV CCACHE_MAXSIZE="64G"
+# Allow for a lot of files (1.5M files, 300 per directory)
+ENV CCACHE_NLEVELS="3"
+# Allow any uid to use cache
+ENV CCACHE_UMASK="000"
+
+COPY --chmod=755 build_and_copy_packages_to_dir.sh /
+ENTRYPOINT ["./build_and_copy_packages_to_dir.sh"]

--- a/irods_runner.debian12.Dockerfile
+++ b/irods_runner.debian12.Dockerfile
@@ -1,0 +1,99 @@
+# syntax=docker/dockerfile:1.5
+#
+# iRODS Runner
+#
+ARG runner_base=debian:12
+FROM ${runner_base} as irods-runner
+
+SHELL [ "/bin/bash", "-c" ]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        apt-transport-https \
+        wget \
+        lsb-release \
+        sudo \
+        gnupg \
+        rsyslog \
+        python3 \
+        python3-psutil \
+        python3-requests \
+        python3-jsonschema \
+        python3-pyodbc \
+        python3-distro \
+        libssl3 \
+        super \
+        lsof \
+        postgresql \
+        odbc-postgresql \
+        libjson-perl \
+    && \
+    rm -rf /tmp/*
+
+# install and configure rsyslog
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        rsyslog \
+    && \
+    rm -rf /tmp/*
+COPY irods.rsyslog /etc/rsyslog.d/00-irods.conf
+COPY irods.logrotate /etc/logrotate.d/irods
+
+# irodsauthuser required for some tests
+# UID and GID ranges picked to hopefully not overlap with anything
+RUN useradd \
+        --key UID_MIN=40050 \
+        --key UID_MAX=49000 \
+        --key GID_MIN=40050 \
+        --key GID_MAX=49000 \
+        --create-home \
+        --shell /bin/bash \
+        irodsauthuser && \
+    echo 'irodsauthuser:;=iamnotasecret' | chpasswd
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        git \
+        vim \
+        nano \
+        rsyslog \
+    && \
+    rm -rf /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list && \
+    wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        'irods-externals*' \
+    && \
+    rm -rf /tmp/*
+
+COPY ICAT.sql /
+COPY --chmod=755 keep_alive.sh /keep_alive.sh
+ENTRYPOINT ["/keep_alive.sh"]

--- a/irods_runner.rocky9.Dockerfile
+++ b/irods_runner.rocky9.Dockerfile
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1.5
+#
+# iRODS Runner
+#
+ARG runner_base=rockylinux:9
+FROM ${runner_base} as irods-runner
+
+SHELL [ "/bin/bash", "-c" ]
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf update -y || [ "$?" -eq 100 ] && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        epel-release \
+        sudo \
+        wget \
+    && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        python3 \
+        python3-distro \
+        python3-jsonschema \
+        python3-psutil \
+        python3-pyodbc \
+        python3-requests \
+        openssl \
+        lsof \
+        postgresql-server \
+        unixODBC \
+    && \
+    rm -rf /tmp/*
+
+# install and configure rsyslog
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        rsyslog \
+    && \
+    sed -i \
+        -e 's/^\(module(load="imuxsock"\)\s*/\1) /' \
+        -e '/^\s\+SysSock.Use="off")/d' \
+        -e '/^\s\+# local messages/d' \
+        /etc/rsyslog.conf \
+    && \
+    sed -i \
+        -e 's/^\(module(load="imjournal"\)\s*/\1) /' \
+        -e '/^\s\+StateFile=/d' \
+        /etc/rsyslog.conf \
+    && \
+    rm -rf /tmp/*
+COPY irods.rsyslog /etc/rsyslog.d/00-irods.conf
+COPY irods.logrotate /etc/logrotate.d/irods
+
+# irodsauthuser required for some tests
+# UID and GID ranges picked to hopefully not overlap with anything
+RUN useradd \
+        --key UID_MIN=40000 \
+        --key UID_MAX=50000 \
+        --key GID_MIN=40000 \
+        --key GID_MAX=50000 \
+        --create-home \
+        --shell /bin/bash \
+        irodsauthuser && \
+    echo 'irodsauthuser:;=iamnotasecret' | chpasswd
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        dnf-plugin-config-manager \
+    && \
+    rpm --import https://packages.irods.org/irods-signing-key.asc && \
+    dnf config-manager -y --add-repo https://packages.irods.org/renci-irods.yum.repo && \
+    dnf config-manager -y --set-enabled renci-irods && \
+    rpm --import https://core-dev.irods.org/irods-core-dev-signing-key.asc && \
+    dnf config-manager -y --add-repo https://core-dev.irods.org/renci-irods-core-dev.yum.repo && \
+    dnf config-manager -y --set-enabled renci-irods-core-dev && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        'irods-externals*' \
+    && \
+    rm -rf /tmp/*
+
+COPY ICAT.sql /
+COPY --chmod=755 keep_alive.sh /keep_alive.sh
+ENTRYPOINT ["/keep_alive.sh"]

--- a/plugin_builder.debian12.Dockerfile
+++ b/plugin_builder.debian12.Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.5
+
+FROM debian:12
+
+SHELL [ "/bin/bash", "-c" ]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        apt-utils \
+        build-essential \
+        git \
+        gnupg \
+        libxml2-dev \
+        lsb-release \
+        python3 \
+        python3-distro \
+        python3-pip \
+        python3-setuptools \
+        sudo \
+        wget \
+    && \
+    rm -rf /tmp/*
+
+ENV python="python3"
+
+# see https://pip.pypa.io/en/stable/topics/vcs-support/
+ARG python_ci_utilities_vcs="git+https://github.com/irods/irods_python_ci_utilities.git@main"
+
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    --mount=type=cache,target=/root/.cache/wheel,sharing=locked \
+    "${python}" -m pip install --break-system-packages "${python_ci_utilities_vcs}" && \
+    rm -rf /tmp/*
+
+ENV file_extension="deb"
+ENV package_manager="apt-get"
+
+COPY --chmod=755 build_and_copy_plugin_packages_to_dir.sh /
+ENTRYPOINT ["./build_and_copy_plugin_packages_to_dir.sh"]

--- a/plugin_builder.rocky9.Dockerfile
+++ b/plugin_builder.rocky9.Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.5
+
+FROM rockylinux:9
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf update -y || [ "$?" -eq 100 ] && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        epel-release \
+        sudo \
+        wget \
+        git \
+        rpm-build \
+        gcc-c++ \
+    && \
+    rm -rf /tmp/*
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    dnf install -y \
+        python3 \
+        python3-devel \
+        python3-pip \
+    && \
+    rm -rf /tmp/*
+
+# TODO: python3 is the only option at this time, so we don't really need this
+ENV python="python3"
+
+# see https://pip.pypa.io/en/stable/topics/vcs-support/
+ARG python_ci_utilities_vcs="git+https://github.com/irods/irods_python_ci_utilities.git@main"
+
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    --mount=type=cache,target=/root/.cache/wheel,sharing=locked \
+    "${python}" -m pip install "${python_ci_utilities_vcs}" && \
+    rm -rf /tmp/*
+
+ENV file_extension="rpm"
+ENV package_manager="dnf"
+
+COPY --chmod=755 build_and_copy_plugin_packages_to_dir.sh /
+ENTRYPOINT ["./build_and_copy_plugin_packages_to_dir.sh"]

--- a/run_debugger.sh
+++ b/run_debugger.sh
@@ -71,6 +71,7 @@ done
 declare -A Os_Map=( ['ubuntu18']='ubuntu:18.04'
                     ['ubuntu20']='ubuntu:20.04'
                     ['debian11']='debian:11'
+                    ['debian12']='debian:12'
                     ['almalinux8']='almalinux:8'
                     ['rocky9']='rockylinux:9'
                     ['centos7']='centos:7' )

--- a/run_debugger.sh
+++ b/run_debugger.sh
@@ -72,6 +72,7 @@ declare -A Os_Map=( ['ubuntu18']='ubuntu:18.04'
                     ['ubuntu20']='ubuntu:20.04'
                     ['debian11']='debian:11'
                     ['almalinux8']='almalinux:8'
+                    ['rocky9']='rockylinux:9'
                     ['centos7']='centos:7' )
 
 base_image=${Os_Map["$OS_NAME"]}


### PR DESCRIPTION
We don't have externals in our repos for these distros yet, so those parts of the Dockerfiles are commented out.

Some other things worth noting:
- In Rocky Linux 9, the `powertools` repo is now the `crb` repo. Supposedly this is how it's always been on RHEL proper.
- The default GCC in Debian 12 is GCC 12.
- In order to install pip packages globally on Debian 12, the argument `--break-system-packages` must be passed to `pip install`
- xmlrunner is provided in the package repositories for Debian 12