### PR TITLE
[#91] Remove Python venvs from EL externals builders

### DIFF
--- a/externals_builder.almalinux8.Dockerfile
+++ b/externals_builder.almalinux8.Dockerfile
@@ -27,8 +27,6 @@ WORKDIR /externals
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     --mount=type=cache,target=/var/cache/yum,sharing=locked \
     git clone https://github.com/irods/externals -b "${externals_branch}" /externals && \
-    python3 -m venv build_env && \
-    source build_env/bin/activate && \
     ./install_prerequisites.py && \
     rm -rf /externals /tmp/*
 

--- a/externals_builder.centos7.Dockerfile
+++ b/externals_builder.centos7.Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
         sudo \
         git \
         python3 \
-        python3-distro \
+        python36-distro \
         devtoolset-10-gcc \
         devtoolset-10-gcc-c++ \
     && \

--- a/externals_builder.centos7.Dockerfile
+++ b/externals_builder.centos7.Dockerfile
@@ -29,8 +29,6 @@ ARG externals_branch="main"
 WORKDIR /externals
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     git clone https://github.com/irods/externals -b "${externals_branch}" /externals && \
-    python3 -m venv build_env && \
-    source build_env/bin/activate && \
     ./install_prerequisites.py && \
     rm -rf /externals /tmp/*
 


### PR DESCRIPTION
Turns out, we don't actually need a venv at all.
Addresses #91