### PR TITLE
[#133] Add option to core builder to enable ASAN

### DIFF
--- a/build_and_copy_packages_to_dir.sh
+++ b/build_and_copy_packages_to_dir.sh
@@ -22,6 +22,8 @@ Available options:
     --exclude-microservice-tests
                             Indicates that iRODS tests implemented as microservices
                             should not be built
+    --enable-address-sanitizer
+                            Indicates that Address Sanitizer should be enabled
     --custom-externals      Path to custom externals packages received via volume mount
     -h, --help              This message
 _EOF_
@@ -84,6 +86,7 @@ build_jobs=0
 debug_config="-DCMAKE_BUILD_TYPE=Release"
 unit_test_config="-DIRODS_UNIT_TESTS_BUILD=YES"
 msi_test_config="-DIRODS_MICROSERVICE_TEST_PLUGINS_BUILD=YES"
+enable_asan="-DIRODS_ENABLE_ADDRESS_SANITIZER=NO"
 custom_externals=""
 
 common_cmake_args=(
@@ -106,6 +109,7 @@ while [ -n "$1" ] ; do
         -C|--ccache)                  common_cmake_args+=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache);;
         --exclude-unit-tests)         unit_test_config="-DIRODS_UNIT_TESTS_BUILD=NO";;
         --exclude-microservice-tests) msi_test_config="-DIRODS_MICROSERVICE_TEST_PLUGINS_BUILD=NO";;
+        --enable-address-sanitizer)   enable_asan="-DIRODS_ENABLE_ADDRESS_SANITIZER=YES";;
         --custom-externals)           shift; custom_externals=$1;;
         -h|--help)                    usage;;
     esac
@@ -132,7 +136,7 @@ if [[ ${icommands_only} -eq 0 ]] ; then
 
     # Build iRODS
     mkdir -p /irods_build && cd /irods_build
-    cmake ${make_program_config} ${debug_config} "${common_cmake_args[@]}" ${unit_test_config} ${msi_test_config} /irods_source
+    cmake ${make_program_config} ${debug_config} "${common_cmake_args[@]}" ${unit_test_config} ${msi_test_config} ${enable_asan} /irods_source
     if [[ -z ${build_jobs} ]] ; then
         ${make_program} package
     else
@@ -168,7 +172,7 @@ fi
 
 # Build iCommands
 mkdir -p /icommands_build && cd /icommands_build
-cmake ${make_program_config} ${debug_config} "${common_cmake_args[@]}" /icommands_source
+cmake ${make_program_config} ${debug_config} "${common_cmake_args[@]}" ${enable_asan} /icommands_source
 if [[ -z ${build_jobs} ]] ; then
     ${make_program} package
 else


### PR DESCRIPTION
Addresses #133

The CMake option defaults to `OFF`, but I just went with `YES`/`NO` to match the other options. `ON`/`YES` and `OFF`/`NO` are equivalent, as I understand it.